### PR TITLE
fix: update vulnerable dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 deepeval>=3.6.0
-pytest>=7.4.0
+pytest>=9.0.3
 pytest-asyncio>=0.21.0
 urllib3>=2.6.3


### PR DESCRIPTION
## Security update

This PR updates vulnerable dependencies reported by GitHub Dependabot alerts.

### Affected advisories/packages
- MODERATE PIP `pytest` in `requirements.txt`: GHSA-6w46-j5rx-g56g (CVE-2025-71176); vulnerable `< 9.0.3`, patched `9.0.3`. https://github.com/advisories/GHSA-6w46-j5rx-g56g

### Compatibility assessment
- Applied minimal patched versions reported by GitHub where possible.
- Consulted GitHub advisory links above plus package-manager resolver metadata during lockfile regeneration.
- No source API usages were changed by automation; this PR only changes dependency manifests/lockfiles unless shown in the diff.
- Review recommended for any major-version package bumps selected by the resolver.

### Changes
```
 requirements.txt | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

```

### Validation
- FAIL `python3 -m pip install --dry-run -r requirements.txt` (.)

