### PR TITLE
Fix inbox empty-state alignment when sidebars are open

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,7 @@
 
 .flow-gtd-inbox-modal {
   padding: 20px;
-  width: min(90vw, 1200px);
+  width: 100%;
   max-width: 1200px;
   margin: 0 auto;
 }

--- a/tests/inbox-modal-layout-style.test.ts
+++ b/tests/inbox-modal-layout-style.test.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Regression tests for inbox processing view layout styling.
+// ABOUTME: Ensures the panel sizes to its container, not the viewport, so content stays centred.
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const repoRoot = join(__dirname, "..");
+
+function readStyles(): string {
+  return readFileSync(join(repoRoot, "styles.css"), "utf-8");
+}
+
+function getCssBlock(styles: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = styles.match(new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`));
+
+  if (!match) {
+    throw new Error(`Missing CSS selector: ${selector}`);
+  }
+
+  return match[1];
+}
+
+function getDeclaration(block: string, property: string): string | undefined {
+  const declaration = block
+    .split(";")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith(`${property}:`));
+
+  return declaration?.slice(property.length + 1).trim();
+}
+
+describe("inbox modal layout styling", () => {
+  it("sizes the panel to its container, not the viewport", () => {
+    const block = getCssBlock(readStyles(), ".flow-gtd-inbox-modal");
+
+    // Viewport units (vw) follow the window width, not the leaf width, so the
+    // panel overflows and content drifts off-centre when sidebars are open.
+    const width = getDeclaration(block, "width");
+    expect(width).toBe("100%");
+    expect(width).not.toMatch(/vw/);
+    expect(getDeclaration(block, "max-width")).toBe("1200px");
+    expect(getDeclaration(block, "margin")).toBe("0 auto");
+  });
+});


### PR DESCRIPTION
## Problem

Reported in #55: "Your inbox is empty!" is off-centre when the Obsidian window/panel is narrower than the window — the content doesn't follow the main panel width.

## Root cause

`.flow-gtd-inbox-modal` (the inbox view's `contentEl`) used `width: min(90vw, 1200px)`. `90vw` is 90% of the **whole window**, not the inbox **panel**. When sidebars are open the panel is narrower than the window, so `contentEl` stayed window-sized, overflowed past the panel's right edge, and the inner `.flow-inbox-redesign` (which centres the empty-state text with `margin: 0 auto`) centred itself within that too-wide element — drifting the text right of the panel centre. The view title is drawn by Obsidian against the panel, hence the visible misalignment.

Measured live with the right sidebar open: panel 498px (centre 249), but content centred at 405 and overflowing to 809px.

## Fix

`width: min(90vw, 1200px)` → `width: 100%`. The element now follows its panel; `max-width: 1200px` + `margin: 0 auto` still cap and centre on very wide panels.

After fix (sidebar open): content width 498 = panel 498, centre 249 = panel centre 249, no overflow. Full-width unaffected.

## Tests

- Added `tests/inbox-modal-layout-style.test.ts` (would fail on the old `90vw`).
- Verified live in Obsidian; `npm run format`, `npm run build`, `npm test` all pass (917 tests).

Fixes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated inbox modal layout to size relative to its container instead of the viewport, improving responsiveness while maintaining maximum width constraints for consistent behavior across screen sizes.

* **Tests**
  * Added regression test to verify modal sizing configuration remains correct.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tavva/flow/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->