### PR TITLE
Flatten multi-line note content into single-line next actions

### DIFF
--- a/src/inbox-item-persistence.ts
+++ b/src/inbox-item-persistence.ts
@@ -21,6 +21,14 @@ const ACTIONS_REQUIRING_SPHERES: readonly string[] = [
   "someday-file",
 ];
 
+function flattenToSingleLine(text: string): string {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join(" ");
+}
+
 export class InboxItemPersistenceService {
   constructor(
     private readonly writer: FileWriter,
@@ -59,7 +67,9 @@ export class InboxItemPersistenceService {
       finalNextActions = [item.original];
     }
 
-    return finalNextActions;
+    // Each next action must occupy a single line in the destination file, so
+    // collapse any multi-line content (e.g. a captured note used as the action).
+    return finalNextActions.map(flattenToSingleLine);
   }
 
   private validateFinalNextActions(item: EditableItem, finalNextActions: string[]): void {

--- a/tests/inbox-item-persistence.test.ts
+++ b/tests/inbox-item-persistence.test.ts
@@ -115,6 +115,22 @@ describe("InboxItemPersistenceService", () => {
     expect(writerMocks.addToNextActionsFile).not.toHaveBeenCalled();
   });
 
+  it("flattens multi-line note content into a single-line next action", async () => {
+    const item: EditableItem = {
+      original: "Call dentist\nabout the crown that fell out",
+      isAIProcessed: false,
+      selectedAction: "next-actions-file",
+      selectedSpheres: ["personal"],
+      sourceNoteLink: "[[Captured note|source]]",
+    };
+
+    await service.persist(item);
+
+    expect(writerMocks.addToNextActionsFile).toHaveBeenCalledTimes(1);
+    const actionsArg = writerMocks.addToNextActionsFile.mock.calls[0][0];
+    expect(actionsArg).toEqual(["Call dentist about the crown that fell out"]);
+  });
+
   it("skips persistence work for trash items", async () => {
     const item: EditableItem = {
       original: "Duplicate",


### PR DESCRIPTION
## Problem

Processing a note inbox item to a next action could write the action across multiple lines, breaking the one-action-per-line invariant. It only showed up when the item had a `(source)` link.

## Root cause

The `(source)` link was a co-symptom, not the cause. Both come from the inbox item being a **note** rather than a line:

- `getNoteItems` stores a note's entire raw file content as the item content (line items are trimmed to a single line; notes are not).
- That becomes `EditableItem.original`.
- `deleteInboxItem` returns a `[[...|source]]` wikilink **only for note items** — hence the correlation with the source link.
- When the action field isn't edited, `resolveFinalNextActions` falls back to `[item.original]`, and the multi-line content is written verbatim as `- [ ] <multi-line text> (source)`.

## Fix

`resolveFinalNextActions` now collapses each resolved action to a single line via a `flattenToSingleLine` helper (split on newlines, trim each line, drop blanks, join with a space). This is the single chokepoint every write path (next-actions-file, create-project, add-to-project, someday-file) reads actions from, so the invariant holds everywhere.

## Testing

- Added a failing-then-passing test: "flattens multi-line note content into a single-line next action".
- Full suite: 920 tests pass. Build clean.

https://claude.ai/code/session_01L6PM2wwRPN7BDUDcB3N6kw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of saved “next action” text so multi-line entries are stored as a single line.
  * Prevented line breaks, extra spacing, and blank lines from appearing in persisted action text.

* **Tests**
  * Added coverage for persisting multi-line note content to ensure it is flattened correctly before saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->